### PR TITLE
added insert_query() to structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cdrs_helpers_derive"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Alex Pikalov <alex.pikalov.khar@gmail.com>"]
 description = "Derive CDRS helper traits"
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Procedural macros that derive helper traits for CDRS Cassandra to Rust types conversion back and forth
 
-The package is under hard development and is absolutely not stable .
+The package is under hard development and is absolutely not stable.
 
 Features:
 
@@ -14,3 +14,4 @@ Features:
 * convert Rust "collection" types into Cassandra query values
 * convert Rust structures into Cassandra query values
 * convert `Option<T>` into Cassandra query value
+* generates an insert method for a Rust struct type

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -53,3 +53,19 @@ fn main() {
     println!("as value {:?}", val);
     println!("among values {:?}", values);
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(DBMirror, TryFromRow)]
+    struct SomeStruct {
+        pk: i32,
+        name: String,
+    }
+
+    #[test]
+    fn test_impl_db_mirror() {
+        assert_eq!("insert into SomeStruct(pk, name) values (?, ?)", SomeStruct::insert_query())
+    }
+}

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -57,6 +57,7 @@ fn main() {
 #[cfg(test)]
 mod test {
     #[derive(DBMirror)]
+    #[allow(dead_code)]
     struct SomeStruct {
         pk: i32,
         name: String,

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -56,9 +56,7 @@ fn main() {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
-    #[derive(DBMirror, TryFromRow)]
+    #[derive(DBMirror)]
     struct SomeStruct {
         pk: i32,
         name: String,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,19 +1,22 @@
 use quote;
 use syn;
+use syn::Field;
 
 pub fn get_struct_fields(ast: &syn::DeriveInput) -> Vec<quote::Tokens> {
-  if let syn::Body::Struct(syn::VariantData::Struct(ref fields)) = ast.body {
-    let fields = fields.iter().map(|field| {
+   struct_fields(ast).iter().map(|field| {
       let name = field.ident.clone().unwrap();
       let value = convert_field_into_rust(field.clone());
       quote!{
         #name: #value
       }
-    });
+    }).collect()
+}
 
-    fields.collect()
+pub fn struct_fields(ast: &syn::DeriveInput) -> &Vec<Field> {
+  if let syn::Body::Struct(syn::VariantData::Struct(ref fields)) = ast.body {
+    fields
   } else {
-    panic!("#[derive(IntoCDRSValue)] is only defined for structs, not for enums!");
+    panic!("The derive macro is defined for structs with named fields, not for enums or unit structs");
   }
 }
 

--- a/src/db_mirror.rs
+++ b/src/db_mirror.rs
@@ -1,7 +1,5 @@
 use common::struct_fields;
 use quote;
-use syn;
-use syn::Ident;
 
 pub fn impl_db_mirror(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;

--- a/src/db_mirror.rs
+++ b/src/db_mirror.rs
@@ -1,18 +1,20 @@
-use common::{get_ident_string, struct_fields};
+use common::struct_fields;
 use quote;
 use syn;
+use syn::Ident;
 
 pub fn impl_db_mirror(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
     let fields = struct_fields(ast);
+    let fields: Vec<Ident> = fields.iter().map(|f| f.ident.clone().unwrap()).collect();
 
     quote! {
         impl #name {
             pub fn insert_query() -> &'static str {
                 concat!("insert into ", stringify!(#name), "(",
-                  #(stringify!(#fields))*
-                 , ") values (",
-                 // Add the amount of '?' for the amount of fields
+                  #(stringify!(#fields, ),)*
+                 ") values (",
+                 #("?"),*
                  ")")
             }
         }

--- a/src/db_mirror.rs
+++ b/src/db_mirror.rs
@@ -5,19 +5,28 @@ use syn::Ident;
 
 pub fn impl_db_mirror(ast: &syn::DeriveInput) -> quote::Tokens {
     let name = &ast.ident;
-    let fields = struct_fields(ast);
-    let fields: Vec<Ident> = fields.iter().map(|f| f.ident.clone().unwrap()).collect();
+    let fields = struct_fields(ast)
+        .iter()
+        .map(|f| f.ident.clone().unwrap())
+        .map(|i| i.to_string())
+        .collect::<Vec<String>>();
+
+    let names = fields
+        .join(", ");
+    let question_marks = fields
+        .iter()
+        .map(|_| "?".to_string()).collect::<Vec<String>>()
+        .join(", ");
 
     quote! {
         impl #name {
             pub fn insert_query() -> &'static str {
                 concat!("insert into ", stringify!(#name), "(",
-                  #(stringify!(#fields, ),)*
+                  #names,
                  ") values (",
-                 #("?"),*
+                 #question_marks,
                  ")")
             }
         }
     }
 }
-

--- a/src/db_mirror.rs
+++ b/src/db_mirror.rs
@@ -1,0 +1,21 @@
+use common::{get_ident_string, struct_fields};
+use quote;
+use syn;
+
+pub fn impl_db_mirror(ast: &syn::DeriveInput) -> quote::Tokens {
+    let name = &ast.ident;
+    let fields = struct_fields(ast);
+
+    quote! {
+        impl #name {
+            pub fn insert_query() -> &'static str {
+                concat!("insert into ", stringify!(#name), "(",
+                  #(stringify!(#fields))*
+                 , ") values (",
+                 // Add the amount of '?' for the amount of fields
+                 ")")
+            }
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate rand;
 extern crate syn;
 
 mod common;
+mod db_mirror;
 mod into_cdrs_value;
 mod try_from_row;
 mod try_from_udt;
@@ -16,6 +17,22 @@ use proc_macro::TokenStream;
 use into_cdrs_value::impl_into_cdrs_value;
 use try_from_row::impl_try_from_row;
 use try_from_udt::impl_try_from_udt;
+use db_mirror::impl_db_mirror;
+
+#[proc_macro_derive(DBMirror)]
+pub fn db_mirror(input: TokenStream) -> TokenStream {
+    // Construct a string representation of the type definition
+    let s = input.to_string();
+
+    // Parse the string representation
+    let ast = syn::parse_derive_input(&s).unwrap();
+
+    // Build the impl
+    let gen = impl_db_mirror(&ast);
+
+    // Return the generated impl
+    gen.parse().unwrap()
+}
 
 #[proc_macro_derive(IntoCDRSValue)]
 pub fn into_cdrs_value(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
I hope more methods can be added to DBMirror. I have a lot of rust structs that are the same as a cassandra table (mirror). I don't want to do the mapping by hand anymore